### PR TITLE
Fixed attribute in header.css

### DIFF
--- a/client/src/components/header/header.css
+++ b/client/src/components/header/header.css
@@ -2,7 +2,7 @@ nav {
     background-color: rgb(125, 141, 191);
   }
 
-.btn-flat {
+nav ul a.btn-flat {
   font-size: 2rem;
   color: white;
 }


### PR DESCRIPTION
Changed '.btn-flat' to 'nav ul a.btn-flat', no longer affects color in datepicker.